### PR TITLE
Fix calling python 2 on arch and friends

### DIFF
--- a/screeps_console/console.py
+++ b/screeps_console/console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from base64 import b64decode
 import getopt

--- a/screeps_console/interactive.py
+++ b/screeps_console/interactive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import atexit
 import command


### PR DESCRIPTION
Using the `python` executable results in python 3 on arch and msys2 (Windows).

I opted to use `python2.7` instead of `python2` because supposedly `python2` doesn't work on macOS. If that tradeoff doesn't make sense, then feel free to change it.