### PR TITLE
Fix it enough that it runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 colorama==0.3.9
 nose==1.3.7
-PyYAML>=3.12,<4
+PyYAML>=6.0.1
 requests>=2.18.3,<3
-Requires==0.0.3
-screepsapi>=0.5.1
+screepsapi @ git+https://github.com/screepers/python-screeps@b4dd23c4d7d987ea73bfc53faca445abd4f5b58d
 six>=1.10.0,<2
-urwid==1.3.1
+urwid==2.1.2
 websocket-client==0.44.0

--- a/screeps_console/interactive.py
+++ b/screeps_console/interactive.py
@@ -401,7 +401,7 @@ if __name__ == "__main__":
                     connectionSettings = settings.getConnection(server)
 
     if not connectionSettings:
-        if server is 'main':
+        if server == 'main':
             host = 'screeps.com'
             secure = True
         else:

--- a/screeps_console/settings.py
+++ b/screeps_console/settings.py
@@ -22,7 +22,7 @@ def getSettings():
         saveSettings(settings)
         return settings
     with open(settingsfile, 'r') as f:
-        settings = yaml.load(f)
+        settings = yaml.safe_load(f)
     return settings
 
 


### PR DESCRIPTION
This bumps the dependencies and updates a couple errors that prevent it from running on the Python 3.11.3 install I have here.

Note that if you're getting SSL errors, it's likely because your Python install is missing its certificates, and you can force them via `WEBSOCKET_CLIENT_CA_BUNDLE=$SSL_CERT_FILE` to get websockets to use another one. Why doesn't it automatically check the standard OpenSSL env-var? Beats me, but that was troublesome enough that I don't want to keep toying with it.

I also had to manually yank [this line](https://github.com/screepers/python-screeps/blob/master/screepsapi/screepsapi.py#L526) from the installed screepsapi package because that looks like a syntax error now 🤷.

Hope this helps someone!